### PR TITLE
Small typo changes in Glossary

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -6,10 +6,10 @@ Blocking
   During the immunostaining procedure, it is important to minimize nonspecific binding of the primary or secondary antibodies. In most cases, this is achieved by blocking, which typically involves adding substances such as normal sera, gelatin, or albumin before immunostaining in order to "occupy" all the non-specific binding sites in the sample.
 
 Deconvolution
-  The process of computationally removing blur from microscopy images by using the known optical properties of the light path to "reassign" pixel intensity away from where it hit the camera and back onto the structure that emitted the light. 
+  The process of computationally removing blur from microscopy images by using the known optical properties of the light path to "reassign" pixel intensity away from where it hit the camera and back onto the structure that emitted the light.
 
 Ex-Vivo imaging
-  Refers to imaging performed on live animal tissue in an external controllable environment (e.g., tissue explant on a petri dish). It enables high-resolution imaging of live tissue that may be otherwise inaccessible within the animal. The tissue is maintained alive on the imaging system through perfusion of oxygenated (95% oxygen and 5% CO2), temperature-controlled media using peristaltic pumps and microfluidics.    
+  Refers to imaging performed on live animal tissue in an external controllable environment (e.g., tissue explant on a petri dish). It enables high-resolution imaging of live tissue that may be otherwise inaccessible within the animal. The tissue is maintained alive on the imaging system through perfusion of oxygenated (95% oxygen and 5% CO2), temperature-controlled media using peristaltic pumps and microfluidics.
 
 Fiji
   [Fiji](https://imagej.net/software/fiji/) Is Just ImageJ. ImageJ2 plus a lot of common plugins.
@@ -18,7 +18,7 @@ Fixation
   Fixation of a specimen refers to the stabilization of the cellular/molecular components within the sample while at the same time stopping any biological function in that sample. The fixative used (e.g., paraformaldehyde, glutaraldehyde, methanol), concentration and conditions (e.g., buffer, temperature) determine the extent of preservation of the cellular and/or molecular structures within a sample, and needs to be optimized depending on the sample or structure that is being imaged.
 
 Image processing
-  Is an operation that can be performed on an image, the result benign another image. There are simple image processing operations, like resizing or rotating an image. And other more advanced like enhancing particular features of an image like circles or lines.
+  Is an operation that can be performed on an image, resulting in another image. Image processing operations can be simple (e.g. resizing or rotating) or more advanced (e.g. enhancing particular features of an image like circles or lines).
 
 Immersion media
  The immersion media is the medium that fills the gap between your objective lens and the glass coverslip or sample. It impacts the numerical aperture of the objective lens {math}`NA=RI * sin(θ)`, thus impacting lateral and axial resolution. It is critical to match the RI of the immersion media with that of the mounting media to minimize aberrations and improve image quality. Immersion media can be air, water, silicone oil, glycerol or oil. 
@@ -30,7 +30,7 @@ Intravital imaging
   It refers to the imaging of cellular structures or biological processes inside a live animal in real time, without extracting the organs or fixing the sample. In general, it requires specific instrumentation or modalities with improved light penetration, such as multiphoton microscopy and is limited to the ability to access the specific organ, often through optical windows. Intravital imaging is overseen by bioethical committees and needs to be approved by IACUC and/or other institutional committees. 
 
 Mounting media
- Is the solution in which your specimen is placed in (mounted). Its purpose is to preserve the sample, including the fluorophores in it,  and enhance the imaging quality during acquisition, by buffering the pH, matching the refractive index throughout the sample (ideally matching it to that of glass) and minimizing photobleaching (depending on the medium) . Mounting media prevents the sample from drying out allowing long-term storage.
+ Is the solution in which your specimen is placed in (mounted). Its purpose is to preserve the sample, including the fluorophores in it,  and enhance the imaging quality during acquisition, by buffering the pH, matching the refractive index throughout the sample (ideally matching it to that of glass) and minimizing photobleaching (depending on the medium). Mounting media prevents the sample from drying out allowing long-term storage.
 
 Object detection
   Is the image processing technique to detect objects within an image. It would not give you a mask of the objects but it could give you a bounding box, or and x,y position.
@@ -49,12 +49,12 @@ ROIs
 
 Segmentation
   Method of dividing an image into multiple parts or regions. There are three different types of segmentation. 
-    - Semantic segmentation, were all parts of an image are part of a class, common in cell biology will be detecting cells and background on an image.
+    - Semantic segmentation, where all parts of an image are part of a class, common in cell biology will be detecting cells and background on an image.
     - Instance segmentation, the segmentation is object based, not just detecting were the cells are but diving each cell as a separate object.
-    - Panoptic Segmentation,  it can be defined as a combination of the prior two, because it identifies the object but also cassifies them. An example in biology might be detecting all the cells on an image and classifying them as dividing vs not.
+    - Panoptic Segmentation, it can be defined as a combination of the prior two, because it identifies the object but also classifies them. An example in biology might be detecting all the cells on an image and classifying them as dividing vs not.
 
 Thresholding
-  The easiest form of image segmentation, it divides the image into two part the background and the foreground (or signal). It creates a binary image were usually the background pixels would be change to a 0 value and the foreground pixels values would be 1.
+  The easiest form of image segmentation, it divides the image into two part the background and the foreground (or signal). It creates a binary image where usually the background pixels would be change to a 0 value and the foreground pixels values would be 1.
 
 Tissue clearing
   Fluorescence imaging of the whole thickness of a piece of tissue is very challenging due to light absorption and scattering induced by the inhomogeneities in refractive indexes within the tissue itself, resulting in poor light penetration. Additionally, light coming from different parts of the sample contribute to fluorescence blur, drastically reducing contrast and resolution in any given plane. As a result, researchers tend to use tissue sectioning techniques to extract information about cellular components and their spatial distribution or relationships from a thin two-dimensional volume. However, most components in any complex biological system such as an organ are not contained within this two-dimensional volume, and therefore, this approach compromises the understanding of the spatial relationships among cellular components. Tissue clearing focused on reducing the inhomogeneities in the tissue by equilibrating the refractive index throughout the sample. This allows light to pass through the tissue and therefore enables high resolution, volumetric imaging of whole organs and tissues using conventional microscopy techniques such as confocal microscopy without the need to physically section the sample.


### PR DESCRIPTION
- "benign" should have been "begin", but the sentence has been rephrased
- were -> where
- cassifies -> classifies
- removed extra spaces