### PR TITLE
Header editing script

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -27,6 +27,11 @@ jobs:
       run: |
         pip install -r requirements.txt
 
+    # Update the headers (redundant here, but for symmetry do it anyway)
+    - name: Update headers
+      run: |
+        python edit_headers.py en
+
     # Build the book
     - name: Build the book
       run: |

--- a/edit_headers.py
+++ b/edit_headers.py
@@ -1,0 +1,58 @@
+import argparse
+import os
+
+def edit_headers(target_language = "en"):
+    translation_dict = {
+        "Sample Preparation":{
+            "en":"Sample Preparation",
+            "es":"Sample Preparation",
+            "pt":"Sample Preparation",
+            "cs":"Sample Preparation",
+        },
+        "Sample Acquisition":{
+            "en":"Sample Acquisition",
+            "es":"Sample Acquisition",
+            "pt":"Sample Acquisition",
+            "cs":"Sample Acquisition",
+        },
+        "Image Analysis and Data Handling":{
+            "en":"Image Analysis and Data Handling",
+            "es":"Image Analysis and Data Handling",
+            "pt":"Image Analysis and Data Handling",
+            "cs":"Image Analysis and Data Handling",
+        },
+        "Data Interpretation":{
+            "en":"Data Interpretation",
+            "es":"Data Interpretation",
+            "pt":"Data Interpretation",
+            "cs":"Data Interpretation",
+        },
+        "Additional Resources":{
+            "en":"Additional Resources",
+            "es":"Additional Resources",
+            "pt":"Additional Resources",
+            "cs":"Additional Resources",
+        },
+    }
+
+    lines = open("_toc.yml", "r").readlines()
+    newlines = []
+    for line in lines:
+        for caption in translation_dict.keys():
+            if line == f"- caption: {caption}\n":
+                line=line.replace(caption,translation_dict[caption][target_language])
+        newlines.append(line)
+    
+    with open("_toc.yml","w") as toc:
+        toc.writelines(newlines)
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Say what language to translate the headers to")
+
+    parser.add_argument("target_language", help="Language to translate header language into. Currently supported options are en, es, pt, and cs")
+
+    args = parser.parse_args()
+
+    edit_headers(target_language=args.target_language)

--- a/edit_headers.py
+++ b/edit_headers.py
@@ -7,31 +7,31 @@ def edit_headers(target_language = "en"):
             "en":"Sample Preparation",
             "es":"Sample Preparation",
             "pt":"Sample Preparation",
-            "cs":"Sample Preparation",
+            "cs":"Příprava vzorku",
         },
         "Sample Acquisition":{
             "en":"Sample Acquisition",
             "es":"Sample Acquisition",
             "pt":"Sample Acquisition",
-            "cs":"Sample Acquisition",
+            "cs":"Snímání vzorku",
         },
         "Image Analysis and Data Handling":{
             "en":"Image Analysis and Data Handling",
             "es":"Image Analysis and Data Handling",
             "pt":"Image Analysis and Data Handling",
-            "cs":"Image Analysis and Data Handling",
+            "cs":"Analýza obrazu a práce s daty",
         },
         "Data Interpretation":{
             "en":"Data Interpretation",
             "es":"Data Interpretation",
             "pt":"Data Interpretation",
-            "cs":"Data Interpretation",
+            "cs":"Interpretace dat",
         },
         "Additional Resources":{
             "en":"Additional Resources",
             "es":"Additional Resources",
             "pt":"Additional Resources",
-            "cs":"Additional Resources",
+            "cs":"Další zdroje",
         },
     }
 

--- a/edit_headers.py
+++ b/edit_headers.py
@@ -6,31 +6,31 @@ def edit_headers(target_language = "en"):
         "Sample Preparation":{
             "en":"Sample Preparation",
             "es":"Sample Preparation",
-            "pt":"Sample Preparation",
+            "pt":"Preparação da amostra",
             "cs":"Příprava vzorku",
         },
         "Sample Acquisition":{
             "en":"Sample Acquisition",
             "es":"Sample Acquisition",
-            "pt":"Sample Acquisition",
+            "pt":"Aquisição da amostra",
             "cs":"Snímání vzorku",
         },
         "Image Analysis and Data Handling":{
             "en":"Image Analysis and Data Handling",
             "es":"Image Analysis and Data Handling",
-            "pt":"Image Analysis and Data Handling",
+            "pt":"Análise de imagens e tratamento de dados",
             "cs":"Analýza obrazu a práce s daty",
         },
         "Data Interpretation":{
             "en":"Data Interpretation",
             "es":"Data Interpretation",
-            "pt":"Data Interpretation",
+            "pt":"Interpretação de dados",
             "cs":"Interpretace dat",
         },
         "Additional Resources":{
             "en":"Additional Resources",
             "es":"Additional Resources",
-            "pt":"Additional Resources",
+            "pt":"Recursos Adicionais",
             "cs":"Další zdroje",
         },
     }

--- a/edit_headers.py
+++ b/edit_headers.py
@@ -5,31 +5,31 @@ def edit_headers(target_language = "en"):
     translation_dict = {
         "Sample Preparation":{
             "en":"Sample Preparation",
-            "es":"Sample Preparation",
+            "es":"Preparación de la muestra",
             "pt":"Preparação da amostra",
             "cs":"Příprava vzorku",
         },
         "Sample Acquisition":{
             "en":"Sample Acquisition",
-            "es":"Sample Acquisition",
+            "es":"Adquisición de muestras",
             "pt":"Aquisição da amostra",
             "cs":"Snímání vzorku",
         },
         "Image Analysis and Data Handling":{
             "en":"Image Analysis and Data Handling",
-            "es":"Image Analysis and Data Handling",
+            "es":"Análisis de Imágenes y Manejo de Datos",
             "pt":"Análise de imagens e tratamento de dados",
             "cs":"Analýza obrazu a práce s daty",
         },
         "Data Interpretation":{
             "en":"Data Interpretation",
-            "es":"Data Interpretation",
+            "es":"Interpretación de Datos",
             "pt":"Interpretação de dados",
             "cs":"Interpretace dat",
         },
         "Additional Resources":{
             "en":"Additional Resources",
-            "es":"Additional Resources",
+            "es":"Recursos Adicionales",
             "pt":"Recursos Adicionais",
             "cs":"Další zdroje",
         },


### PR DESCRIPTION
The translated books still have English section headers, because those come straight from the `toc`; this allows us to edit the file to provide the right header at build time.

@emiglietta @mccruz07 @martinschatz-cz , at whatever pace suits you, could you edit this branch and/or drop me an email or comment letting me know your preferred translations for these 5 section headers? Ty!